### PR TITLE
Added marmalade repl tools and test policy that allows transferring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/kda-env/bootstrap-modules/repl-marmalade-tools.pact
+++ b/kda-env/bootstrap-modules/repl-marmalade-tools.pact
@@ -1,0 +1,39 @@
+(module repl-marmalade-tools GOV
+  (defcap GOV () true)
+  (use marmalade.ledger)
+
+  (defun create-token 
+    (
+      token-id:string 
+      precision:integer 
+      scheme:string 
+      data:string 
+      datum:object 
+      policy:module{kip.token-policy-v1}
+    )
+    (let* 
+      (
+        (uri (kip.token-manifest.uri scheme data))
+        (datum (kip.token-manifest.create-datum uri datum))
+        (manifest (kip.token-manifest.create-manifest uri [datum]))
+      )
+      
+      (marmalade.ledger.create-token token-id precision manifest policy)
+    )
+  )
+
+  (defun fund-account-with-token (account-name:string token-id:string key:string amount:decimal)
+  "Fund a marmalade account from nothing"
+    (env-data { "k": [key]})
+    (with-applied-env
+      (let ((ks:guard (read-keyset 'k)))
+        (create-account token-id account-name ks)
+        (test-capability (MINT token-id account-name amount))
+        (mint token-id account-name ks amount)))
+  )
+
+  (defun fund-accounts-with-token (account-names:[string] token-id:string amount:decimal)
+    "Fund a list of coin accounts with a constant amount. the key is dervied from the account name"
+    (map (lambda (x) (fund-account-with-token x token-id (+ x "-key") amount)) account-names)
+  )
+)

--- a/kda-env/init-test-accounts.repl
+++ b/kda-env/init-test-accounts.repl
@@ -2,12 +2,33 @@
 
 (begin-tx)
 (load "./bootstrap-modules/repl-coin-tools.pact")
+(load "./bootstrap-modules/repl-marmalade-tools.pact")
+(commit-tx)
+
+
+(begin-tx)
+(env-data {"init":true})
+(load "./test-policies/token-policy-transfer.pact")
 (commit-tx)
 
 
 (begin-tx)
 (use repl-coin-tools)
 (fund-accounts ["alice", "bob", "carol", "dave"] 1000.0)
+(commit-tx)
+
+
+(begin-tx)
+(use repl-marmalade-tools)
+(env-data {
+  "mint-guard": ["mint"],
+  "burn-guard": ["burn"],
+  "sale-guard": ["sale"],
+  "transfer-guard": ["transfer"]
+})
+(create-token "m-token" 0 "schema" "data" {"trait":"powerful"} free.token-policy-transfer)
+(env-keys ["mint"])
+(fund-accounts-with-token ["alice", "bob", "carol", "dave"] "m-token" 100.0)
 (commit-tx)
 
 (env-enable-repl-natives false)

--- a/kda-env/test-policies/token-policy-transfer.pact
+++ b/kda-env/test-policies/token-policy-transfer.pact
@@ -1,0 +1,114 @@
+(namespace "free")
+
+;  (define-keyset "free.nft-staker-admin" (read-keyset "nft-staker-admin"))
+
+(module token-policy-transfer GOV
+
+  (defcap GOV ()
+    (enforce-keyset "free.nft-staker-admin")
+  )
+
+  (implements kip.token-policy-v1)
+  (use kip.token-policy-v1 [token-info])
+
+  (defschema guards ; ID is the token-id
+    mint-guard:guard
+    burn-guard:guard
+    sale-guard:guard
+    transfer-guard:guard
+  )
+
+  (deftable policy-guards:{guards})
+
+  (defun get-guards:object{guards} (token:object{token-info})
+    (read policy-guards (at 'id token))
+  )
+
+  (defun enforce-ledger:bool ()
+    (enforce-guard (marmalade.ledger.ledger-guard))
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (enforce-ledger)
+    (enforce-guard (at "mint-guard" (get-guards token)))
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (enforce-ledger)
+    (enforce-guard (at "burn-guard" (get-guards token)))
+  )
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    (enforce-ledger)
+    (insert policy-guards (at "id" token)
+      { "mint-guard": (read-keyset "mint-guard")
+      , "burn-guard": (read-keyset "burn-guard")
+      , "sale-guard": (read-keyset "sale-guard")
+      , "transfer-guard": (read-keyset 'transfer-guard) })
+    true
+  )
+
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      sale-id:string )
+    (enforce-ledger)
+    (enforce-sale-pact sale-id)
+    (enforce-guard (at "sale-guard" (get-guards token)))
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    (enforce-ledger)
+    (enforce-sale-pact sale-id)
+    (enforce-guard (at "sale-guard" (get-guards token)))
+  )
+
+  (defun enforce-sale-pact:bool (sale:string)
+    "Enforces that SALE is id for currently executing pact"
+    (enforce (= sale (pact-id)) "Invalid pact/sale id")
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (enforce-ledger)
+    true
+  )
+
+  (defun enforce-crosschain:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      target-chain:string
+      amount:decimal )
+    (enforce-ledger)
+    (enforce-guard (at "transfer-guard" (get-guards token)))
+  )
+)
+
+(if (read-msg "init")
+  [ (create-table policy-guards) ]
+  "No init")


### PR DESCRIPTION
Marmalade repl tools lets you create marmalade tokes for testing easily.

I have added a basic token that allows transfers to make it easier to test marmalade token interactions.

bob, carol, alice, and dave are all funded with 100.0 of the test marmalade token.